### PR TITLE
fix(package.json): remove invalid bin field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "author": "Andrew Powell <andrew@shellscape.org>",
   "homepage": "https://github.com/shellscape/webpack-hot-client",
   "bugs": "https://github.com/shellscape/webpack-hot-client/issues",
-  "bin": "",
   "main": "lib/index.js",
   "engines": {
     "node": ">= 6.9.0 < 7.0.0 || >= 8.9.0"


### PR DESCRIPTION
If the `bin` field is present, it must point to a valid path within the package. Since the `bin` field was an empty string, it didn’t, so it should be removed. This was causing warnings when installing this package as a dependency.

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When using this as a dependency, yarn outputs the following line:

```
warning webpack-hot-client@4.1.2: Invalid bin field for "webpack-hot-client".
```

This change fixes that.